### PR TITLE
Fix typo in DHT_ESP8266.ino

### DIFF
--- a/examples/DHT_ESP8266/DHT_ESP8266.ino
+++ b/examples/DHT_ESP8266/DHT_ESP8266.ino
@@ -39,6 +39,6 @@ void loop()
   Serial.print(dht.computeHeatIndex(temperature, humidity, false), 1);
   Serial.print("\t\t");
   Serial.println(dht.computeHeatIndex(dht.toFahrenheit(temperature), humidity, true), 1);
-  Delay(2000);
+  delay(2000);
 }
 


### PR DESCRIPTION
The provided example does not compile unless you change `Delay` to `delay`.

Fixes #31